### PR TITLE
Mantenimiento 2022-06-15 (versión 0.2.1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 
 # Do not put this files on a distribution package
 /.github/                   export-ignore
+/.phive/                    export-ignore
 /build/                     export-ignore
 /tests/                     export-ignore
 /.editorconfig              export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,6 @@
 /phpcs.xml.dist             export-ignore
 /phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
+
+# Do not count these files on github code language
+/tests/_files/**            linguist-detectable=false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-/.github/*  @phpcfdi/core-mantainers
+/.github/*  @phpcfdi/core-maintainers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,99 +1,106 @@
 name: build
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
   push:
-    branches: [ main ]
+    branches: [ "main" ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
+# Actions
+# shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+
 jobs:
-
-  ci: # this job runs all the development tools
-
-    name: PHP 8.0 (full)
+  phpcs:
+    name: Coding standards (phpcs)
     runs-on: "ubuntu-latest"
-
     steps:
-
       - name: Checkout
-        uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
-          extensions: bcmath, openssl, soap
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, phpcs, php-cs-fixer, phpstan, cs2pr
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install project dependencies
-        run: composer upgrade --no-interaction --no-progress --prefer-dist
-
-      - name: Code style (phpcs)
+      - name: Run phpcs
         run: phpcs -q --report=checkstyle | cs2pr
 
-      - name: Code style (php-cs-fixer)
+  php-cs-fixer:
+    name: Coding standards (php-cs-fixer)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: cs2pr, php-cs-fixer
+        env:
+          fail-fast: true
+      - name: Run php-cs-fixer
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
-      - name: Tests
-        run: vendor/bin/phpunit --testdox --verbose
-
-      - name: Code analysis (phpstan)
-        run: phpstan analyse --no-progress --verbose
-
-  build: # this job runs tests on all php supported versions
-
-    name: PHP ${{ matrix.php-versions }} (tests)
+  phpunit:
+    name: Tests on PHP ${{ matrix.php-versions }} (phpunit)
     runs-on: "ubuntu-latest"
-
     strategy:
       matrix:
-        php-versions: ['7.4']
-
+        php-versions: ['7.4', '8.0', '8.1']
     steps:
-
       - name: Checkout
-        uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: bcmath, openssl, soap
+          extensions: sqlite3
           coverage: none
-          tools: composer:v2, cs2pr
+          tools: composer:v2
         env:
           fail-fast: true
-
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-
-      - name: Tests
+      - name: Run phpunit
         run: vendor/bin/phpunit --testdox --verbose
+
+  phpstan:
+    name: Static analysis (phpstan)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: composer:v2, phpstan
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Run phpstan
+        run: phpstan analyse --no-progress --verbose

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.1.0" installed="3.1.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.0" installed="3.6.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.0" installed="3.6.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^0.12.98" installed="0.12.98" location="./tools/phpstan" copy="false"/>
-  <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.9.4" installed="3.9.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.8.1" installed="1.8.1" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,20 +11,19 @@ declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
         '@PHP74Migration' => true,
         '@PHP74Migration:risky' => true,
-        // PSR12 (remove when php-cs-fixer reaches ^3.1.1)
-        'class_definition' => ['space_before_parenthesis' => true],
         // symfony
-        // 'class_attributes_separation' => true, // conflict with PSR12
+        'class_attributes_separation' => true, // conflict with PSR12
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'arguments']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -42,11 +41,12 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->append([__FILE__])
-            ->exclude(['vendor', 'build'])
+            ->exclude(['vendor', 'tools', 'build']),
     )
 ;

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2021 - 2022 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,11 @@
             "PhpCfdi\\CeUtils\\Tests\\": "tests/"
         }
     },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
+    },
     "scripts": {
         "dev:build": [
             "@dev:fix-style",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ Cambios en entorno de desarrollo:
 - Se agrega la revisión de compatiblidad de PHP 8.1.
 - Se dividen los pasos de construcción completa en pequeños trabajos independientes.
 - Se corrige el grupo de mantenedores del proyecto.
+- Se ignora `tests/_files` de la detección lingüística del proyecto.
 
 ### Versión 0.2.0 2021-09-11
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,25 @@ aunque sí su incorporación en la rama principal de trabajo. Generalmente, se t
 
 ## Listado de cambios
 
+### Versión 0.2.1 2022-06-15
+
+Esta liberación corrige el proceso de integración continua, modifica el código fuente del proyecto y
+mejora el paquete redistribuible, aunque no contiene ningún cambio de funcionamiento.
+
+Cambios al código público:
+
+- Se actualiza la licencia a 2022.
+- Se actualiza el código para seguir el estilo actualizado.
+- Se permite la ejecución del plugin `ergebnis/composer-normalize`.
+- Se ignora `.phive/` del paquete de distribución.
+
+Cambios en entorno de desarrollo:
+
+- Se actualizan las herramientas de desarrollo y el archivo de configuración de `php-cs-fixer`.
+- Se agrega la revisión de compatiblidad de PHP 8.1.
+- Se dividen los pasos de construcción completa en pequeños trabajos independientes.
+- Se corrige el grupo de mantenedores del proyecto.
+
 ### Versión 0.2.0 2021-09-11
 
 - Se adopta el proyecto de César Aquilera `@blacktrue` como parte de PhpCfdi.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,14 +4,13 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios no liberados en una versión
 
-Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
-versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente se tratan de cambios en el desarrollo.
+Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de versión,
+aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
 
 ## Listado de cambios
 
-### Version 0.2.0 2021-09-11
+### Versión 0.2.0 2021-09-11
 
-- Se adopta el proyecto de César Aquilera (@blacktrue) como parte de PhpCfdi.
+- Se adopta el proyecto de César Aquilera `@blacktrue` como parte de PhpCfdi.
 - Se actualizan los archivos de proyecto y de desarrollo.
-- Se agrega la dependencia omitida ``
-- Cambian el codebase
+- Se hace la primera liberación pública.

--- a/src/AbstractCreator.php
+++ b/src/AbstractCreator.php
@@ -17,7 +17,6 @@ use PhpCfdi\Credentials\Credential;
 abstract class AbstractCreator
 {
     use XsltBuilderPropertyTrait;
-
     use XmlResolverPropertyTrait;
 
     public function __construct(?XmlResolver $xmlResolver = null)
@@ -49,7 +48,7 @@ abstract class AbstractCreator
 
         $this->getRootNode()->addAttributes([
             'Sello' => base64_encode(
-                $credential->privateKey()->sign($cadenaDeOrigen, $this->getSelloAlgorithm())
+                $credential->privateKey()->sign($cadenaDeOrigen, $this->getSelloAlgorithm()),
             ),
         ]);
 

--- a/src/Validate/AuxiliarCuentas13/Base/DocumentDefinition.php
+++ b/src/Validate/AuxiliarCuentas13/Base/DocumentDefinition.php
@@ -20,7 +20,7 @@ class DocumentDefinition extends BaseDocumentDefinition
         return new self(
             'AUXCTA13DOC',
             AuxiliarCuentas13Definition::ELEMENT_NAME,
-            AuxiliarCuentas13Definition::NAMESPACE
+            AuxiliarCuentas13Definition::NAMESPACE,
         );
     }
 }

--- a/src/Validate/AuxiliarCuentas13/Base/DocumentFollowSchemas.php
+++ b/src/Validate/AuxiliarCuentas13/Base/DocumentFollowSchemas.php
@@ -20,7 +20,7 @@ class DocumentFollowSchemas extends BaseDocumentFollowSchemas
         return new self(
             'AUXCTA13SCHEMA',
             AuxiliarCuentas13Definition::NAMESPACE,
-            AuxiliarCuentas13Definition::XSD_LOCATION
+            AuxiliarCuentas13Definition::XSD_LOCATION,
         );
     }
 }

--- a/src/Validate/AuxiliarFolios13/Base/DocumentDefinition.php
+++ b/src/Validate/AuxiliarFolios13/Base/DocumentDefinition.php
@@ -20,7 +20,7 @@ class DocumentDefinition extends BaseDocumentDefinition
         return new self(
             'AUXFOL13DOC',
             AuxiliarFolios13Definition::ELEMENT_NAME,
-            AuxiliarFolios13Definition::NAMESPACE
+            AuxiliarFolios13Definition::NAMESPACE,
         );
     }
 }

--- a/src/Validate/AuxiliarFolios13/Base/DocumentFollowSchemas.php
+++ b/src/Validate/AuxiliarFolios13/Base/DocumentFollowSchemas.php
@@ -20,7 +20,7 @@ class DocumentFollowSchemas extends BaseDocumentFollowSchemas
         return new self(
             'AUXFOL13SCHEMA',
             AuxiliarFolios13Definition::NAMESPACE,
-            AuxiliarFolios13Definition::XSD_LOCATION
+            AuxiliarFolios13Definition::XSD_LOCATION,
         );
     }
 }

--- a/src/Validate/Balanza13/CuentasSaldoFinal.php
+++ b/src/Validate/Balanza13/CuentasSaldoFinal.php
@@ -27,7 +27,7 @@ final class CuentasSaldoFinal implements ValidatorInterface
     {
         $assert = $asserts->put(
             'BAL13SF01',
-            'Para cada cuenta, el saldo final debe ser el saldo inicial más el debe menos el deber'
+            'Para cada cuenta, el saldo final debe ser el saldo inicial más el debe menos el deber',
         );
         $nodes = $root->searchNodes('BCE:Ctas');
         $failedIndexes = [];
@@ -40,7 +40,7 @@ final class CuentasSaldoFinal implements ValidatorInterface
         $explanation = sprintf(
             'Número de nodos: %d, Nodos con errores: %s.',
             $nodes->count(),
-            implode(', ', $failedIndexes) ?: '(ninguno)'
+            implode(', ', $failedIndexes) ?: '(ninguno)',
         );
         $assert->setStatus(Status::when([] === $failedIndexes), $explanation);
     }
@@ -64,7 +64,7 @@ final class CuentasSaldoFinal implements ValidatorInterface
                 $node['Haber'],
                 $node['SaldoFin'],
                 (string) $equals,
-            )
+            ),
         );
         return $equals;
     }

--- a/src/Validate/Balanza13/FechaModificacionBalanza.php
+++ b/src/Validate/Balanza13/FechaModificacionBalanza.php
@@ -23,7 +23,7 @@ class FechaModificacionBalanza implements ValidatorInterface
     {
         $assert = $asserts->put(
             'BAL13FMB01',
-            'Si el tipo de envío es complemento entonces la fecha de modificación de balanza debe existir'
+            'Si el tipo de envío es complemento entonces la fecha de modificación de balanza debe existir',
         );
         if ('C' === $root['TipoEnvio']) {
             $assert->setStatus(Status::when('' !== $root['FechaModBal']));

--- a/src/Validate/Common/BaseCertificate.php
+++ b/src/Validate/Common/BaseCertificate.php
@@ -49,15 +49,15 @@ abstract class BaseCertificate implements
         $certificateAssert = $asserts->put('01', 'El certificado se puede leer', Status::ok());
         $asserts->put(
             $this->getAssertCode('02'),
-            'El número del certificado es el mismo que el contenido en el certificado'
+            'El número del certificado es el mismo que el contenido en el certificado',
         );
         $asserts->put(
             $this->getAssertCode('03'),
-            'El Rfc del documento es el mismo que el contenido en el certificado'
+            'El Rfc del documento es el mismo que el contenido en el certificado',
         );
         $asserts->put(
             $this->getAssertCode('04'),
-            'El sello coincide con los datos del documento y el certificado'
+            'El sello coincide con los datos del documento y el certificado',
         );
 
         try {
@@ -65,7 +65,7 @@ abstract class BaseCertificate implements
         } catch (UnexpectedValueException $exception) {
             $certificateAssert->setStatus(
                 Status::error(),
-                $exception->getMessage()
+                $exception->getMessage(),
             );
             return;
         }
@@ -73,13 +73,13 @@ abstract class BaseCertificate implements
         $asserts->putStatus(
             $this->getAssertCode('02'),
             Status::when($certificate->serialNumber()->bytes() === $root['noCertificado']),
-            sprintf('Esperado: %s. Actual: %s', $certificate->serialNumber()->bytes(), $root['noCertificado'])
+            sprintf('Esperado: %s. Actual: %s', $certificate->serialNumber()->bytes(), $root['noCertificado']),
         );
 
         $asserts->putStatus(
             $this->getAssertCode('03'),
             Status::when($certificate->rfc() === $root['RFC']),
-            sprintf('Esperado: %s. Actual: %s', $certificate->rfc(), $root['RFC'])
+            sprintf('Esperado: %s. Actual: %s', $certificate->rfc(), $root['RFC']),
         );
 
         $sourceString = $this->buildSourceString();
@@ -88,7 +88,7 @@ abstract class BaseCertificate implements
         $asserts->putStatus(
             $this->getAssertCode('04'),
             Status::when($certificate->publicKey()->verify($sourceString, $signature, OPENSSL_ALGO_SHA1)),
-            "Cadena de origen: $sourceString"
+            "Cadena de origen: $sourceString",
         );
     }
 

--- a/src/Validate/Common/BaseCurrency.php
+++ b/src/Validate/Common/BaseCurrency.php
@@ -50,7 +50,7 @@ abstract class BaseCurrency implements ValidatorInterface
             $this->getAssertCode(sprintf('-%03d', $count)),
             'La moneda solo se especifica en caso de que sea diferente a moneda nacional',
             Status::when(! $currencyExists || ! in_array($currency, ['', 'MXN'], true)),
-            sprintf('Moneda: %s, Nodo: %s', $currencyExplanation, $location)
+            sprintf('Moneda: %s, Nodo: %s', $currencyExplanation, $location),
         );
     }
 }

--- a/src/Validate/Common/BaseDifferentRfc.php
+++ b/src/Validate/Common/BaseDifferentRfc.php
@@ -54,7 +54,7 @@ abstract class BaseDifferentRfc implements ValidatorInterface
             $this->getAssertCode(sprintf('-%03d', $count)),
             'El RFC de referencia debe ser distinto al registro del que envía los datos',
             Status::when($issuerRfc !== $rfc),
-            sprintf('RFC Emisor: %s, RFC: %s, Nodo: %s', $issuerRfc, $rfc, $location)
+            sprintf('RFC Emisor: %s, RFC: %s, Nodo: %s', $issuerRfc, $rfc, $location),
         );
     }
 }

--- a/src/Validate/Common/BaseDocumentDefinition.php
+++ b/src/Validate/Common/BaseDocumentDefinition.php
@@ -58,7 +58,7 @@ abstract class BaseDocumentDefinition implements ValidatorInterface
             $this->getAssertName('01'),
             'El documento tiene el nombre del nodo principal correcto',
             $status,
-            sprintf('Esperado: %s, Actual: %s.', $this->getRootElementName(), $nodeName)
+            sprintf('Esperado: %s, Actual: %s.', $this->getRootElementName(), $nodeName),
         );
 
         return $status->isOk();
@@ -74,7 +74,7 @@ abstract class BaseDocumentDefinition implements ValidatorInterface
             $this->getAssertName('02'),
             'El documento tiene el espacio de nombres correcto',
             $status,
-            sprintf('Esperado: %s, Actual: %s.', $this->getNamespace(), $namespace)
+            sprintf('Esperado: %s, Actual: %s.', $this->getNamespace(), $namespace),
         );
 
         return $status->isOk();

--- a/src/Validate/Common/BaseDocumentFollowSchemas.php
+++ b/src/Validate/Common/BaseDocumentFollowSchemas.php
@@ -26,7 +26,6 @@ abstract class BaseDocumentFollowSchemas implements
     RequireXmlResolverInterface
 {
     use XmlStringPropertyTrait;
-
     use XmlResolverPropertyTrait;
 
     private string $assertPrefix;
@@ -69,11 +68,11 @@ abstract class BaseDocumentFollowSchemas implements
     {
         $locationAssert = $asserts->put(
             $this->getAssertName('01'),
-            'El documento usa la ruta de la definición de esquema XML definido'
+            'El documento usa la ruta de la definición de esquema XML definido',
         );
         $xsdAssert = $asserts->put(
             $this->getAssertName('02'),
-            'El documento cumple con la definición del esquema XML'
+            'El documento cumple con la definición del esquema XML',
         );
 
         $content = $this->getXmlString();
@@ -89,7 +88,7 @@ abstract class BaseDocumentFollowSchemas implements
         $xsdErrors = $this->validateXsdSchemas($schemaValidator, $schemas);
         $xsdAssert->setStatus(
             Status::when([] === $xsdErrors),
-            implode(PHP_EOL, $xsdErrors)
+            implode(PHP_EOL, $xsdErrors),
         );
     }
 
@@ -102,7 +101,7 @@ abstract class BaseDocumentFollowSchemas implements
         $locationMatches = $this->getXsdLocation() === $location;
         $locationAssert->setStatus(
             Status::when($locationMatches),
-            sprintf('Esperado: %s. Actual: %s.', $this->getXsdLocation(), $location)
+            sprintf('Esperado: %s. Actual: %s.', $this->getXsdLocation(), $location),
         );
         return $locationMatches;
     }

--- a/src/Validate/Common/BaseExchangeRate.php
+++ b/src/Validate/Common/BaseExchangeRate.php
@@ -52,7 +52,7 @@ abstract class BaseExchangeRate implements ValidatorInterface
             $this->getAssertCode(sprintf('-%03d', $count)),
             'El tipo de cambio debe tener un valor en caso de que la moneda sea diferente a moneda nacional',
             Status::when(! $currencyExists || '' !== $exchangeRate),
-            sprintf('Moneda: %s, TipCamb: %s, Nodo: %s', $currencyExplanation, $exchangeRate, $location)
+            sprintf('Moneda: %s, TipCamb: %s, Nodo: %s', $currencyExplanation, $exchangeRate, $location),
         );
     }
 }

--- a/src/Validate/Common/BaseNumOrden.php
+++ b/src/Validate/Common/BaseNumOrden.php
@@ -29,7 +29,7 @@ abstract class BaseNumOrden implements ValidatorInterface
             $numOrden = $root['NumOrden'];
             $assert->setStatus(
                 Status::when('' !== $numOrden),
-                sprintf('TipoSolicitud: %s, NumOrden: %s', $tipoSolicitud, $numOrden)
+                sprintf('TipoSolicitud: %s, NumOrden: %s', $tipoSolicitud, $numOrden),
             );
         }
     }

--- a/src/Validate/Common/BaseNumTramite.php
+++ b/src/Validate/Common/BaseNumTramite.php
@@ -28,7 +28,7 @@ abstract class BaseNumTramite implements ValidatorInterface
             $numTramite = $root['NumTramite'];
             $assert->setStatus(
                 Status::when('' !== $numTramite),
-                sprintf('TipoSolicitud: %s, Numtramite: %s', $tipoSolicitud, $numTramite)
+                sprintf('TipoSolicitud: %s, Numtramite: %s', $tipoSolicitud, $numTramite),
             );
         }
     }

--- a/src/Validate/Common/BaseUniquePolizaNumber.php
+++ b/src/Validate/Common/BaseUniquePolizaNumber.php
@@ -53,7 +53,7 @@ abstract class BaseUniquePolizaNumber implements ValidatorInterface
             $this->getAssertCode(sprintf('-%03d', $index + 1)),
             'En un mes ordinario no debe repetirse un mismo número de póliza',
             Status::when(0 === $count),
-            sprintf('NumUnIdenPol: %s, Apariciones: %d', $numUnIdenPol, $count)
+            sprintf('NumUnIdenPol: %s, Apariciones: %d', $numUnIdenPol, $count),
         );
     }
 

--- a/src/Validate/Hydrater.php
+++ b/src/Validate/Hydrater.php
@@ -16,9 +16,7 @@ use CfdiUtils\XmlResolver\XmlResolverPropertyTrait;
 class Hydrater implements XmlResolverPropertyInterface, XsltBuilderPropertyInterface
 {
     use XmlResolverPropertyTrait;
-
     use XmlStringPropertyTrait;
-
     use XsltBuilderPropertyTrait;
 
     public function hydrate(ValidatorInterface $validator): void

--- a/src/Validate/MultiValidator.php
+++ b/src/Validate/MultiValidator.php
@@ -66,7 +66,7 @@ abstract class MultiValidator
     {
         if (! is_subclass_of($validatorClass, ValidatorInterface::class)) {
             throw new LogicException(
-                sprintf('The class %s is not a subclass of %s', $validatorClass, ValidatorInterface::class)
+                sprintf('The class %s is not a subclass of %s', $validatorClass, ValidatorInterface::class),
             );
         }
         $validator = call_user_func([$validatorClass, 'create']);

--- a/tests/Traits/WithFakeCsd.php
+++ b/tests/Traits/WithFakeCsd.php
@@ -13,7 +13,7 @@ trait WithFakeCsd
         return Credential::openFiles(
             $this->filePath('fake-csd/EKU9003173C9.cer'),
             $this->filePath('fake-csd/EKU9003173C9.key'),
-            trim($this->fileContents('fake-csd/EKU9003173C9-password.txt'))
+            trim($this->fileContents('fake-csd/EKU9003173C9-password.txt')),
         );
     }
 }

--- a/tests/Unit/AuxiliarCuentasCreator13Test.php
+++ b/tests/Unit/AuxiliarCuentasCreator13Test.php
@@ -91,7 +91,7 @@ final class AuxiliarCuentasCreator13Test extends TestCase
                 'Concepto' => 'concepto 2',
                 'Debe' => '50',
                 'Haber' => '0',
-            ]
+            ],
         );
 
         $creator->addSello($credential);

--- a/tests/Unit/Elements/AuxiliarCuentas13/AuxiliarCtasTest.php
+++ b/tests/Unit/Elements/AuxiliarCuentas13/AuxiliarCtasTest.php
@@ -46,7 +46,7 @@ final class AuxiliarCtasTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiCuenta(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);

--- a/tests/Unit/Elements/AuxiliarCuentas13/CuentaTest.php
+++ b/tests/Unit/Elements/AuxiliarCuentas13/CuentaTest.php
@@ -46,7 +46,7 @@ final class CuentaTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiDetalleAux(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);

--- a/tests/Unit/Elements/AuxiliarFolios13/DetAuxFolTest.php
+++ b/tests/Unit/Elements/AuxiliarFolios13/DetAuxFolTest.php
@@ -46,7 +46,7 @@ final class DetAuxFolTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiComprNal(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);
@@ -74,7 +74,7 @@ final class DetAuxFolTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiComprNalOtr(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);
@@ -102,7 +102,7 @@ final class DetAuxFolTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiComprExt(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);

--- a/tests/Unit/Elements/AuxiliarFolios13/RepAuxFolTest.php
+++ b/tests/Unit/Elements/AuxiliarFolios13/RepAuxFolTest.php
@@ -44,7 +44,7 @@ final class RepAuxFolTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiDetalleAux(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);

--- a/tests/Unit/Elements/Balanza13/BalanzaTest.php
+++ b/tests/Unit/Elements/Balanza13/BalanzaTest.php
@@ -46,7 +46,7 @@ final class BalanzaTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiCuenta(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);

--- a/tests/Unit/Elements/Catalogo13/CatalogoTest.php
+++ b/tests/Unit/Elements/Catalogo13/CatalogoTest.php
@@ -46,7 +46,7 @@ final class CatalogoTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiCuenta(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);

--- a/tests/Unit/Elements/Polizas13/PolizasTest.php
+++ b/tests/Unit/Elements/Polizas13/PolizasTest.php
@@ -46,7 +46,7 @@ final class PolizasTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiPoliza(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);

--- a/tests/Unit/Elements/Polizas13/TransaccionTest.php
+++ b/tests/Unit/Elements/Polizas13/TransaccionTest.php
@@ -51,7 +51,7 @@ final class TransaccionTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiCompNal(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);
@@ -81,7 +81,7 @@ final class TransaccionTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiCompNalOtr(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);
@@ -111,7 +111,7 @@ final class TransaccionTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiCompExt(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);
@@ -141,7 +141,7 @@ final class TransaccionTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiCheque(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);
@@ -171,7 +171,7 @@ final class TransaccionTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiTransferencia(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);
@@ -201,7 +201,7 @@ final class TransaccionTest extends TestCase
         $this->assertCount(0, $node);
         $multiReturn = $node->multiOtrMetodoPago(
             ['id' => 'first'],
-            ['id' => 'second']
+            ['id' => 'second'],
         );
         $this->assertSame($multiReturn, $node);
         $this->assertCount(2, $node);


### PR DESCRIPTION
Esta PR corrige el proceso de integración continua, modifica el código fuente del proyecto y mejora el paquete redistribuible, aunque no contiene ningún cambio de funcionamiento.

Cambios al código público:

- Se actualiza la licencia a 2022.
- Se actualiza el código para seguir el estilo actualizado.
- Se permite la ejecución del plugin `ergebnis/composer-normalize`.
- Se ignora `.phive/` del paquete de distribución.

Cambios en entorno de desarrollo:

- Se actualizan las herramientas de desarrollo y el archivo de configuración de `php-cs-fixer`.
- Se agrega la revisión de compatiblidad de PHP 8.1.
- Se dividen los pasos de construcción completa en pequeños trabajos independientes.
- Se corrige el grupo de mantenedores del proyecto.
