### PR TITLE
Corrección de clases de validación y mantenimiento [v0.2.3]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -94,7 +94,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -86,7 +86,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: sqlite3
+          extensions: bcmath
           coverage: none
           tools: composer:v2
         env:
@@ -87,6 +87,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
+          extensions: bcmath
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.11.0" installed="3.11.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.8.6" installed="1.8.6" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.41.1" installed="3.41.1" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.8.0" installed="3.8.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.8.0" installed="3.8.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.50" installed="1.10.50" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,11 +18,11 @@ return (new PhpCsFixer\Config())
         '@PHP74Migration' => true,
         '@PHP74Migration:risky' => true,
         // symfony
-        'class_attributes_separation' => true, // conflict with PSR12
+        'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'arguments']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuciones
 
-Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][homepage].
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][project].
 
 Este proyecto se apega al siguiente [Código de Conducta][coc].
 Al participar en este proyecto y en su comunidad, deberás seguir este código.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 - 2022 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2021 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: http://img.shields.io/badge/source-phpcfdi/ceutils-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/ceutils?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/ceutils?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/ceutils/build/main?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/ceutils/build.yml?branch=main&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/ceutils/main?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/ceutils/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/ceutils?style=flat-square

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,11 @@ Cambios en el entorno de desarrollo:
 - Se actualiza el año de la licencia.
 - Se corrige la insignia de construcción.
 - Se actualizan los archivos de configuración de las herramientas de estilo de código.
+- Se actualiza el archivo de integración continua de GitHub:
+    - Se agrega PHP 8.2 y PHP 8.3 a la matriz de pruebas.
+    - Los trabajos corren en PHP 8.3.
+    - Se configura la extensión `bcmath`.
+    - Se actualiza la directiva `::set-output` a `$GITHUB_OUTPUT`.
 - Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.2.2 2022-09-28

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Para más información consulta <https://github.com/phpstan/phpstan/issues/10286
 Cambios en el entorno de desarrollo:
 
 - Se actualiza el año de la licencia.
+- Se corrige la insignia de construcción.
 
 ### Versión 0.2.2 2022-09-28
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ Cambios en el entorno de desarrollo:
 - Se actualiza el año de la licencia.
 - Se corrige la insignia de construcción.
 - Se actualizan los archivos de configuración de las herramientas de estilo de código.
+- Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.2.2 2022-09-28
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ aunque sí su incorporación en la rama principal de trabajo. Generalmente, se t
 
 ## Listado de cambios
 
+### Versión 0.2.3 2023-12-18
+
+Algunas clases de validadores no estaban marcadas como *finales*.
+PHPStan detectó esto como un problema al utilizar el método estático `create(): self`.
+Para más información consulta <https://github.com/phpstan/phpstan/issues/10286>.
+
 ### Versión 0.2.2 2022-09-28
 
 Se actualizan las dependencias:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ Algunas clases de validadores no estaban marcadas como *finales*.
 PHPStan detectó esto como un problema al utilizar el método estático `create(): self`.
 Para más información consulta <https://github.com/phpstan/phpstan/issues/10286>.
 
+Cambios en el entorno de desarrollo:
+
+- Se actualiza el año de la licencia.
+
 ### Versión 0.2.2 2022-09-28
 
 Se actualizan las dependencias:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ Cambios en el entorno de desarrollo:
 
 - Se actualiza el año de la licencia.
 - Se corrige la insignia de construcción.
+- Se actualizan los archivos de configuración de las herramientas de estilo de código.
 
 ### Versión 0.2.2 2022-09-28
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ Cambios en el entorno de desarrollo:
     - Los trabajos corren en PHP 8.3.
     - Se configura la extensión `bcmath`.
     - Se actualiza la directiva `::set-output` a `$GITHUB_OUTPUT`.
+    - Se permite ejecutar los flujos de trabajo a voluntad.
 - Se actualizan las herramientas de desarrollo.
 
 ### Versión 0.2.2 2022-09-28

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-2 based) coding standard.</description>
 

--- a/src/Validate/AuxiliarCuentas13/AuxiliarCuentas13MultiValidator.php
+++ b/src/Validate/AuxiliarCuentas13/AuxiliarCuentas13MultiValidator.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\CeUtils\Validate\AuxiliarCuentas13;
 
 use PhpCfdi\CeUtils\Validate\MultiValidator;
 
-class AuxiliarCuentas13MultiValidator extends MultiValidator
+final class AuxiliarCuentas13MultiValidator extends MultiValidator
 {
     protected array $validatorClasses = [
         Base\DocumentDefinition::class,

--- a/src/Validate/AuxiliarCuentas13/Base/Certificate.php
+++ b/src/Validate/AuxiliarCuentas13/Base/Certificate.php
@@ -15,7 +15,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseCertificate;
  * AUXCTA13CER03 - El Rfc del documento es el mismo que el contenido en el certificado
  * AUXCTA13CER04 - El sello coincide con los datos del documento y el certificado
  */
-class Certificate extends BaseCertificate
+final class Certificate extends BaseCertificate
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarCuentas13/Base/DocumentDefinition.php
+++ b/src/Validate/AuxiliarCuentas13/Base/DocumentDefinition.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentDefinition;
  * AUXCTA13DOC01 - El documento tiene el nombre del nodo principal correcto
  * AUXCTA13DOC02 - El documento tiene el espacio de nombres correcto
  */
-class DocumentDefinition extends BaseDocumentDefinition
+final class DocumentDefinition extends BaseDocumentDefinition
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarCuentas13/Base/DocumentFollowSchemas.php
+++ b/src/Validate/AuxiliarCuentas13/Base/DocumentFollowSchemas.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentFollowSchemas;
  * AUXCTA13SCHEMA01 - El documento usa la ruta de la definición de esquema XML definido
  * AUXCTA13SCHEMA02 - El documento cumple con la definición del esquema XML
  */
-class DocumentFollowSchemas extends BaseDocumentFollowSchemas
+final class DocumentFollowSchemas extends BaseDocumentFollowSchemas
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarCuentas13/Base/NumOrden.php
+++ b/src/Validate/AuxiliarCuentas13/Base/NumOrden.php
@@ -12,7 +12,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseNumOrden;
  * AUXCTANOR01 - El número de orden es requerido cuando el tipo de solicitud
  *                 es Acto de Fiscalización o Fiscalización Compulsa
  */
-class NumOrden extends BaseNumOrden
+final class NumOrden extends BaseNumOrden
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarCuentas13/Base/NumTramite.php
+++ b/src/Validate/AuxiliarCuentas13/Base/NumTramite.php
@@ -11,7 +11,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseNumTramite;
  *
  * AUXCTA13NTR01 - El número de trámite es requerido cuando el tipo de solicitud es Devolución o Compensación
  */
-class NumTramite extends BaseNumTramite
+final class NumTramite extends BaseNumTramite
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarFolios13/AuxiliarFolios13MultiValidator.php
+++ b/src/Validate/AuxiliarFolios13/AuxiliarFolios13MultiValidator.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\CeUtils\Validate\AuxiliarFolios13;
 
 use PhpCfdi\CeUtils\Validate\MultiValidator;
 
-class AuxiliarFolios13MultiValidator extends MultiValidator
+final class AuxiliarFolios13MultiValidator extends MultiValidator
 {
     protected array $validatorClasses = [
         Base\DocumentDefinition::class,

--- a/src/Validate/AuxiliarFolios13/Base/Certificate.php
+++ b/src/Validate/AuxiliarFolios13/Base/Certificate.php
@@ -15,7 +15,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseCertificate;
  * AUXFOL13CER03 - El Rfc del documento es el mismo que el contenido en el certificado
  * AUXFOL13CER04 - El sello coincide con los datos del documento y el certificado
  */
-class Certificate extends BaseCertificate
+final class Certificate extends BaseCertificate
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarFolios13/Base/DocumentDefinition.php
+++ b/src/Validate/AuxiliarFolios13/Base/DocumentDefinition.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentDefinition;
  * AUXFOL13DOC01 - El documento tiene el nombre del nodo principal correcto
  * AUXFOL13DOC02 - El documento tiene el espacio de nombres correcto
  */
-class DocumentDefinition extends BaseDocumentDefinition
+final class DocumentDefinition extends BaseDocumentDefinition
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarFolios13/Base/DocumentFollowSchemas.php
+++ b/src/Validate/AuxiliarFolios13/Base/DocumentFollowSchemas.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentFollowSchemas;
  * AUXFOL13SCHEMA01 - El documento usa la ruta de la definición de esquema XML definido
  * AUXFOL13SCHEMA02 - El documento cumple con la definición del esquema XML
  */
-class DocumentFollowSchemas extends BaseDocumentFollowSchemas
+final class DocumentFollowSchemas extends BaseDocumentFollowSchemas
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarFolios13/Base/NumOrden.php
+++ b/src/Validate/AuxiliarFolios13/Base/NumOrden.php
@@ -12,7 +12,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseNumOrden;
  * AUXFOL13NOR01 - El número de orden es requerido cuando el tipo de solicitud
  *                 es Acto de Fiscalización o Fiscalización Compulsa
  */
-class NumOrden extends BaseNumOrden
+final class NumOrden extends BaseNumOrden
 {
     public static function create(): self
     {

--- a/src/Validate/AuxiliarFolios13/Base/NumTramite.php
+++ b/src/Validate/AuxiliarFolios13/Base/NumTramite.php
@@ -11,7 +11,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseNumTramite;
  *
  * AUXFOL13NTR01 - El número de trámite es requerido cuando el tipo de solicitud es Devolución o Compensación
  */
-class NumTramite extends BaseNumTramite
+final class NumTramite extends BaseNumTramite
 {
     public static function create(): self
     {

--- a/src/Validate/Balanza13/Balanza13MultiValidator.php
+++ b/src/Validate/Balanza13/Balanza13MultiValidator.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\CeUtils\Validate\Balanza13;
 
 use PhpCfdi\CeUtils\Validate\MultiValidator;
 
-class Balanza13MultiValidator extends MultiValidator
+final class Balanza13MultiValidator extends MultiValidator
 {
     protected array $validatorClasses = [
         Base\DocumentDefinition::class,

--- a/src/Validate/Balanza13/Base/Certificate.php
+++ b/src/Validate/Balanza13/Base/Certificate.php
@@ -15,7 +15,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseCertificate;
  * BAL13CER03 - El Rfc del documento es el mismo que el contenido en el certificado
  * BAL13CER04 - El sello coincide con los datos del documento y el certificado
  */
-class Certificate extends BaseCertificate
+final class Certificate extends BaseCertificate
 {
     public static function create(): self
     {

--- a/src/Validate/Balanza13/Base/DocumentDefinition.php
+++ b/src/Validate/Balanza13/Base/DocumentDefinition.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentDefinition;
  * BAL13DOC01 - El documento tiene el nombre del nodo principal correcto
  * BAL13DOC02 - El documento tiene el espacio de nombres correcto
  */
-class DocumentDefinition extends BaseDocumentDefinition
+final class DocumentDefinition extends BaseDocumentDefinition
 {
     public static function create(): self
     {

--- a/src/Validate/Balanza13/Base/DocumentFollowSchemas.php
+++ b/src/Validate/Balanza13/Base/DocumentFollowSchemas.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentFollowSchemas;
  * BAL13SCHEMA01 - El documento usa la ruta de la definición de esquema XML definido
  * BAL13SCHEMA02 - El documento cumple con la definición del esquema XML
  */
-class DocumentFollowSchemas extends BaseDocumentFollowSchemas
+final class DocumentFollowSchemas extends BaseDocumentFollowSchemas
 {
     public static function create(): self
     {

--- a/src/Validate/Balanza13/FechaModificacionBalanza.php
+++ b/src/Validate/Balanza13/FechaModificacionBalanza.php
@@ -12,7 +12,7 @@ use PhpCfdi\CeUtils\Validate\ValidatorInterface;
 /**
  * BAL13FMB01 - Si el tipo de envío es complemento entonces la fecha de modificación de balanza debe existir
  */
-class FechaModificacionBalanza implements ValidatorInterface
+final class FechaModificacionBalanza implements ValidatorInterface
 {
     public static function create(): self
     {

--- a/src/Validate/Catalogo13/Base/Certificate.php
+++ b/src/Validate/Catalogo13/Base/Certificate.php
@@ -15,7 +15,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseCertificate;
  * CAT13CER03 - El Rfc del documento es el mismo que el contenido en el certificado
  * CAT13CER04 - El sello coincide con los datos del documento y el certificado
  */
-class Certificate extends BaseCertificate
+final class Certificate extends BaseCertificate
 {
     public static function create(): self
     {

--- a/src/Validate/Catalogo13/Base/DocumentDefinition.php
+++ b/src/Validate/Catalogo13/Base/DocumentDefinition.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentDefinition;
  * CAT13DOC01 - El documento tiene el nombre del nodo principal correcto
  * CAT13DOC02 - El documento tiene el espacio de nombres correcto
  */
-class DocumentDefinition extends BaseDocumentDefinition
+final class DocumentDefinition extends BaseDocumentDefinition
 {
     public static function create(): self
     {

--- a/src/Validate/Catalogo13/Base/DocumentFollowSchemas.php
+++ b/src/Validate/Catalogo13/Base/DocumentFollowSchemas.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentFollowSchemas;
  * CAT13SCHEMA01 - El documento usa la ruta de la definición de esquema XML definido
  * CAT13SCHEMA02 - El documento cumple con la definición del esquema XML
  */
-class DocumentFollowSchemas extends BaseDocumentFollowSchemas
+final class DocumentFollowSchemas extends BaseDocumentFollowSchemas
 {
     public static function create(): self
     {

--- a/src/Validate/Catalogo13/Catalogo13MultiValidator.php
+++ b/src/Validate/Catalogo13/Catalogo13MultiValidator.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\CeUtils\Validate\Catalogo13;
 
 use PhpCfdi\CeUtils\Validate\MultiValidator;
 
-class Catalogo13MultiValidator extends MultiValidator
+final class Catalogo13MultiValidator extends MultiValidator
 {
     protected array $validatorClasses = [
         Base\DocumentDefinition::class,

--- a/src/Validate/Polizas13/Base/Certificate.php
+++ b/src/Validate/Polizas13/Base/Certificate.php
@@ -15,7 +15,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseCertificate;
  * PLZ13CER03 - El Rfc del documento es el mismo que el contenido en el certificado
  * PLZ13CER04 - El sello coincide con los datos del documento y el certificado
  */
-class Certificate extends BaseCertificate
+final class Certificate extends BaseCertificate
 {
     public static function create(): self
     {

--- a/src/Validate/Polizas13/Base/DocumentDefinition.php
+++ b/src/Validate/Polizas13/Base/DocumentDefinition.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentDefinition;
  * PLZ13DOC01 - El documento tiene el nombre del nodo principal correcto
  * PLZ13DOC02 - El documento tiene el espacio de nombres correcto
  */
-class DocumentDefinition extends BaseDocumentDefinition
+final class DocumentDefinition extends BaseDocumentDefinition
 {
     public static function create(): self
     {

--- a/src/Validate/Polizas13/Base/DocumentFollowSchemas.php
+++ b/src/Validate/Polizas13/Base/DocumentFollowSchemas.php
@@ -13,7 +13,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseDocumentFollowSchemas;
  * PLZ13SCHEMA01 - El documento usa la ruta de la definición de esquema XML definido
  * PLZ13SCHEMA02 - El documento cumple con la definición del esquema XML
  */
-class DocumentFollowSchemas extends BaseDocumentFollowSchemas
+final class DocumentFollowSchemas extends BaseDocumentFollowSchemas
 {
     public static function create(): self
     {

--- a/src/Validate/Polizas13/Base/NumOrden.php
+++ b/src/Validate/Polizas13/Base/NumOrden.php
@@ -12,7 +12,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseNumOrden;
  * PLZ13NOR01 - El número de orden es requerido cuando el tipo de solicitud
  *              es Acto de Fiscalización o Fiscalización Compulsa
  */
-class NumOrden extends BaseNumOrden
+final class NumOrden extends BaseNumOrden
 {
     public static function create(): self
     {

--- a/src/Validate/Polizas13/Base/NumTramite.php
+++ b/src/Validate/Polizas13/Base/NumTramite.php
@@ -11,7 +11,7 @@ use PhpCfdi\CeUtils\Validate\Common\BaseNumTramite;
  *
  * PLZ13NTR01 - El número de trámite es requerido cuando el tipo de solicitud es Devolución o Compensación
  */
-class NumTramite extends BaseNumTramite
+final class NumTramite extends BaseNumTramite
 {
     public static function create(): self
     {

--- a/src/Validate/Polizas13/Polizas13MultiValidator.php
+++ b/src/Validate/Polizas13/Polizas13MultiValidator.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\CeUtils\Validate\Polizas13;
 
 use PhpCfdi\CeUtils\Validate\MultiValidator;
 
-class Polizas13MultiValidator extends MultiValidator
+final class Polizas13MultiValidator extends MultiValidator
 {
     protected array $validatorClasses = [
         Base\DocumentDefinition::class,


### PR DESCRIPTION
Algunas clases de validadores no estaban marcadas como *finales*.
PHPStan detectó esto como un problema al utilizar el método estático `create(): self`.
Para más información consulta <https://github.com/phpstan/phpstan/issues/10286>.

Cambios en el entorno de desarrollo:

- Se actualiza el año de la licencia.
- Se corrige la insignia de construcción.
- Se actualizan los archivos de configuración de las herramientas de estilo de código.
- Se actualiza el archivo de integración continua de GitHub:
    - Se agrega PHP 8.2 y PHP 8.3 a la matriz de pruebas.
    - Los trabajos corren en PHP 8.3.
    - Se configura la extensión `bcmath`.
    - Se actualiza la directiva `::set-output` a `$GITHUB_OUTPUT`.
- Se actualizan las herramientas de desarrollo.
